### PR TITLE
Adapted output of the reusable action to allow for csv.gz in addition to rds

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -72,12 +72,12 @@ diabetes_algo:
       --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
-      --df_output=data_processed.rds
+      --df_output=data_processed.csv.gz
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      rds: output/data_processed.rds
+      csv.gz: output/data_processed.csv.gz
 ```
 
 Alternatively, the input arguments can also be specified using a `config:` key in the YAML as follows.
@@ -97,12 +97,12 @@ diabetes_algo_via_config:
       birth_date: your_dob_date_variable
       tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
       ## more arguments
-      df_output: data_processed.rds
+      df_output: data_processed.csv.gz
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      rds: output/data_processed.rds
+      csv.gz: output/data_processed.csv.gz
 ```
 
 For more information about reusable actions see [here](https://docs.opensafely.org/actions-reusable/).

--- a/README.Rmd
+++ b/README.Rmd
@@ -72,12 +72,12 @@ diabetes_algo:
       --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
-      --df_output=data_processed.csv.gz
+      --df_output=data_processed.csv.gz #or data_processed.rds
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      csv.gz: output/data_processed.csv.gz
+      csv.gz: output/data_processed.csv.gz #or data_processed.rds
 ```
 
 Alternatively, the input arguments can also be specified using a `config:` key in the YAML as follows.
@@ -97,12 +97,12 @@ diabetes_algo_via_config:
       birth_date: your_dob_date_variable
       tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
       ## more arguments
-      df_output: data_processed.csv.gz
+      df_output: data_processed.csv.gz #or data_processed.rds
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      csv.gz: output/data_processed.csv.gz
+      csv.gz: output/data_processed.csv.gz #or data_processed.rds
 ```
 
 For more information about reusable actions see [here](https://docs.opensafely.org/actions-reusable/).

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ input variables, find
     tmp_nonmetform_drugs_dmd_date, and tmp_diabetes_medication_date [default
     tmp_first_diabetes_diag_date]
 
-    --df_output=FILENAME.RDS
-    Output dataset. rds file. This is assumed to be added to the directory 'output'
-    [default data_processed.rds]
+    --df_output=FILENAME.CSV.GZ
+    Output dataset. csv.gz or rds file. This is assumed to be added to the
+    directory 'output' [default data_processed.csv.gz]
 
     --config=
     Config parsed from the YAML
@@ -176,12 +176,12 @@ diabetes_algo:
       --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
-      --df_output=data_processed.csv.gz
+      --df_output=data_processed.csv.gz #or data_processed.rds
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      csv.gz: output/data_processed.csv.gz
+      csv.gz: output/data_processed.csv.gz #or data_processed.rds
 ```
 
 Alternatively, the input arguments can also be specified using a
@@ -202,12 +202,12 @@ diabetes_algo_via_config:
       birth_date: your_dob_date_variable
       tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
       ## more arguments
-      df_output: data_processed.csv.gz
+      df_output: data_processed.csv.gz #or data_processed.rds
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      csv.gz: output/data_processed.csv.gz
+      csv.gz: output/data_processed.csv.gz #or data_processed.rds
 ```
 
 For more information about reusable actions see

--- a/README.md
+++ b/README.md
@@ -176,12 +176,12 @@ diabetes_algo:
       --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
-      --df_output=data_processed.rds
+      --df_output=data_processed.csv.gz
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      rds: output/data_processed.rds
+      csv.gz: output/data_processed.csv.gz
 ```
 
 Alternatively, the input arguments can also be specified using a
@@ -202,12 +202,12 @@ diabetes_algo_via_config:
       birth_date: your_dob_date_variable
       tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
       ## more arguments
-      df_output: data_processed.rds
+      df_output: data_processed.csv.gz
   needs:
   - generate_dataset
   outputs:
     highly_sensitive:
-      rds: output/data_processed.rds
+      csv.gz: output/data_processed.csv.gz
 ```
 
 For more information about reusable actions see

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -100,7 +100,7 @@ option_list <- list(
               help = "First diabetes diagnosis date variable, i.e. minimum of t1dm_date, t2dm_date, otherdm_date, gestationaldm_date, tmp_poccdm_date, tmp_nonmetform_drugs_dmd_date, and tmp_diabetes_medication_date [default %default]",
               metavar = "YYYY-MM-DD"),
   make_option("--df_output", type = "character", default = "data_processed.csv.gz",
-              help = "Output dataset. csv.gz file. This is assumed to be added to the directory 'output' [default %default]",
+              help = "Output dataset. csv.gz or rds file. This is assumed to be added to the directory 'output' [default %default]",
               metavar = "filename.csv.gz"),
   make_option("--config", type = "character", default = "",
               help = "Config parsed from the YAML",

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -12,7 +12,7 @@
 # 10 Save output dataset (data_processed.rds)
 ################################################################################
 
-print("diabetes-algo version: v0.0.2")
+print("diabetes-algo version: v0.0.3")
 
 ################################################################################
 # Import libraries and functions
@@ -99,9 +99,9 @@ option_list <- list(
   make_option("--tmp_first_diabetes_diag_date", type = "character", default = "tmp_first_diabetes_diag_date",
               help = "First diabetes diagnosis date variable, i.e. minimum of t1dm_date, t2dm_date, otherdm_date, gestationaldm_date, tmp_poccdm_date, tmp_nonmetform_drugs_dmd_date, and tmp_diabetes_medication_date [default %default]",
               metavar = "YYYY-MM-DD"),
-  make_option("--df_output", type = "character", default = "data_processed.rds",
-              help = "Output dataset. rds file. This is assumed to be added to the directory 'output' [default %default]",
-              metavar = "filename.rds"),
+  make_option("--df_output", type = "character", default = "data_processed.csv.gz",
+              help = "Output dataset. csv.gz file. This is assumed to be added to the directory 'output' [default %default]",
+              metavar = "filename.csv.gz"),
   make_option("--config", type = "character", default = "",
               help = "Config parsed from the YAML",
               metavar = "")
@@ -268,3 +268,4 @@ data_processed <- merge(non_core, core,
 ################################################################################
 print("Save output")
 write_rds(data_processed, paste0("output/", opt$df_output))
+write.csv(data_processed, gzfile(paste0("output/", opt$df_output, ".csv.gz")), row.names = FALSE)

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -41,9 +41,7 @@ dataset.define_population(patients.exists_for_patient())
 #######################################################################################
 # DEFINE necessary variables to build algo
 #######################################################################################
-## See https://github.com/opensafely/post-covid-diabetes/blob/main/analysis/common_variables.py 
-## See xxx
-## add emergency table?
+## See https://github.com/opensafely/post-covid-diabetes/blob/main/analysis/common_variables.py
 
 ## Demographics
 dataset.birth_date = patients.date_of_birth

--- a/project.yaml
+++ b/project.yaml
@@ -8,12 +8,12 @@ actions:
         dataset: output/input.csv
 
   data_process:
-    run: r:v2 analysis/data_process.R --df_input input.csv
+    run: r:v2 analysis/data_process.R --df_input input.csv --df_output data_processed.csv.gz
     needs:
     - generate_dataset
     outputs:
       highly_sensitive:
-        rds: output/data_processed.rds
+        csv.gz: output/data_processed.csv.gz
       #moderately_sensitive:
       #  arguments: output/args-data_processed.csv
 
@@ -24,12 +24,12 @@ actions:
           dataset: output/input2.csv
   
   data_process_2:
-    run: r:v2 analysis/data_process.R --df_input input2.csv --df_output data_processed_2.rds
+    run: r:v2 analysis/data_process.R --df_input input2.csv --df_output data_processed_2.csv.gz
     needs:
     - generate_dataset_2
     outputs:
       highly_sensitive:
-        rds: output/data_processed_2.rds
+        csv.gz: output/data_processed_2.csv.gz
 
   generate_dataset_3:
         run: ehrql:v1 generate-dataset analysis/dataset_definition.py --output output/input.arrow
@@ -41,12 +41,12 @@ actions:
     run: r:v2 analysis/data_process.R
     config:
       df_input: input.arrow
-      df_output: data_processed_3.rds
+      df_output: data_processed_3.csv.gz
     needs:
     - generate_dataset_3
     outputs:
       highly_sensitive:
-        rds: output/data_processed_3.rds
+        csv.gz: output/data_processed_3.csv.gz
 
   generate_dataset_4:
           run: ehrql:v1 generate-dataset analysis/dataset_definition.py --output output/input4.csv.gz
@@ -55,9 +55,9 @@ actions:
               dataset: output/input4.csv.gz
       
   data_process_4:
-    run: r:v2 analysis/data_process.R --df_input input4.csv.gz --df_output data_processed_4.rds
+    run: r:v2 analysis/data_process.R --df_input input4.csv.gz --df_output data_processed_4.csv.gz
     needs:
     - generate_dataset_4
     outputs:
       highly_sensitive:
-        rds: output/data_processed_4.rds
+        csv.gz: output/data_processed_4.csv.gz


### PR DESCRIPTION
cvs.gz needed e.g. for @table_from_file in ehrQL. Whichever output (rds or csv.gz) is specified in the YAML action will be provided.