### PR TITLE
customize diagnosis date sources for each diabetes type & clarify primary care codelist input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v0.0.10](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.10)
+
+* Updated CHANGELOG
+* Updated the algorithm to allow user-customizable source definition of the diagnosis dates
+* Clarified that the provided codelists are just examples
+
 # [v0.0.9](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.9)
 
 * Updated CHANGELOG

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,16 +14,18 @@ The action:
 - Loads and double-checks 21 input variables
 - Runs the diabetes adjudication algorithm (Figure 1 below) to define the following Diabetes types: 
 -   Gestational, Type 2, Type 1, Other, Unlikely (variable 'cat_diabetes': GDM, T2DM, T1DM, DM_other, DM_unlikely)
-- Besides the categorical type variable, it provides the diagnosis date for each type. The default is:
+- Besides the categorical type variable, it provides the diagnosis date for each type. The default choice of diagnosis date sources for each type is:
 -   gestationaldm_date: First date from GDM clinical codes
 -   t2dm_date: First date from T1DM clinical codes, T2DM clinical codes, unspecific diabetes clinical codes, and diabetes medication codes
 -   t1dm_date: First date from T1DM clinical codes, T2DM clinical codes, unspecific diabetes clinical codes, and diabetes medication codes
 -   otherdm_date: First date from T1DM clinical codes, T2DM clinical codes, unspecific diabetes clinical codes, diabetes medication codes, and diabetes-specific procedure codes
+- Version 0.0.10 allows users to change the above-mentioned default choice of diagnosis date sources and define their own sources, see args gestationaldm_date_sources, t1dm_date_sources, t2dm_date_sources, otherdm_date_sources
 
 ## Usage
 
 The input variables/arguments/options to the action are specified using the flags style (i.e., `--argname=argvalue`).
 Below, you find a detailed description of each input variable including examples for codelists to use when defining these variables in the OpenSAFELY dataset definition.
+IMPORTANT: The used codelists here are just examples. Users have to double-check these. Important is to adhere to the specified source (primary or secondary care) where these codelists should come from.
 Copy-paste the argument names into your yaml and map them to your input variable names.
 An example of a dataset definition that defines each 21 input variables, find [here](https://github.com/alainamstutz/diabetes-algo/blob/main/analysis/dataset_definition.py). 
 ```{r, include=FALSE}
@@ -48,7 +50,7 @@ source_lines <- function(file, lines) {
 }
 # Note: in the following command the last line should be the line that
 # creates the opt_parser object using OptionParser(...)
-source_lines("analysis/data_process.R", 34:110)
+source_lines("analysis/data_process.R", 34:122)
 optparse::print_help(opt_parser)
 ```
 
@@ -75,7 +77,7 @@ diabetes_algo:
   run: >
     diabetes-algo:[version]
       --birth_date=your_dob_date_variable
-      --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
+      --tmp_t1dm_primarycare_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
       --df_output=data_processed.csv.gz #or data_processed.rds
@@ -101,7 +103,7 @@ diabetes_algo_via_config:
   config:
       df_input: input.arrow
       birth_date: your_dob_date_variable
-      tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
+      tmp_t1dm_primarycare_date: your_t2dm_from_primcare_date_variable
       ## more arguments
       df_output: data_processed.csv.gz #or data_processed.rds
   needs:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The action:
   - Gestational, Type 2, Type 1, Other, Unlikely (variable
     ‘cat\_diabetes’: GDM, T2DM, T1DM, DM\_other, DM\_unlikely)
   - Besides the categorical type variable, it provides the diagnosis
-    date for each type. The default is:
+    date for each type. The default choice of diagnosis date sources for
+    each type is:
   - gestationaldm\_date: First date from GDM clinical codes
   - t2dm\_date: First date from T1DM clinical codes, T2DM clinical
     codes, unspecific diabetes clinical codes, and diabetes medication
@@ -26,6 +27,10 @@ The action:
   - otherdm\_date: First date from T1DM clinical codes, T2DM clinical
     codes, unspecific diabetes clinical codes, diabetes medication
     codes, and diabetes-specific procedure codes
+  - Version 0.0.10 allows users to change the above-mentioned default
+    choice of diagnosis date sources and define their own sources, see
+    args gestationaldm\_date\_sources, t1dm\_date\_sources,
+    t2dm\_date\_sources, otherdm\_date\_sources
 
 ## Usage
 
@@ -33,6 +38,9 @@ The input variables/arguments/options to the action are specified using
 the flags style (i.e., `--argname=argvalue`). Below, you find a detailed
 description of each input variable including examples for codelists to
 use when defining these variables in the OpenSAFELY dataset definition.
+IMPORTANT: The used codelists here are just examples. Users have to
+double-check these. Important is to adhere to the specified source
+(primary or secondary care) where these codelists should come from.
 Copy-paste the argument names into your yaml and map them to your input
 variable names. An example of a dataset definition that defines each 21
 input variables, find
@@ -47,7 +55,7 @@ input variables, find
     the directory 'output' [default input.csv]
     
     --remove_helper=TRUE/FALSE
-    Logical, indicating whether all helper variables (_tmp and step_) are removed
+    Logical, indicating whether all helper variables (tmp_ and step_) are removed
     [default TRUE]
     
     --birth_date=YYYY-MM-DD
@@ -55,7 +63,7 @@ input variables, find
     
     --ethnicity_cat=ETHNICITY_VARNAME
     Ethnicity, in 6 categories, coded as follows: White, Mixed, Asian, Black,
-    Other, Unknown. Guidance (https://pubmed.ncbi.nlm.nih.gov/38987774/) [default
+    Other, Unknown. Guidance: https://pubmed.ncbi.nlm.nih.gov/38987774/ [default
     ethnicity_cat]
     
     --t1dm_date=YYYY-MM-DD
@@ -65,9 +73,9 @@ input variables, find
     https://www.opencodelists.org/codelist/user/alainamstutz/type-1-diabetes-secondary-care/5eab6d93/)
     care [default t1dm_date]
     
-    --tmp_t1dm_ctv3_date=YYYY-MM-DD
+    --tmp_t1dm_primarycare_date=YYYY-MM-DD
     First type 1 DM diagnosis date, from primary care only [default
-    tmp_t1dm_ctv3_date]
+    tmp_t1dm_primarycare_date]
     
     --tmp_t1dm_count_num=T1DM_COUNT_VARNAME
     Count of all recorded Type 1 DM diagnosis codes, from both primary and
@@ -80,9 +88,9 @@ input variables, find
     https://www.opencodelists.org/codelist/user/alainamstutz/type-2-diabetes-secondary-care/77bae0c8/)
     care [default t2dm_date]
     
-    --tmp_t2dm_ctv3_date=YYYY-MM-DD
+    --tmp_t2dm_primarycare_date=YYYY-MM-DD
     First type 2 DM diagnosis date, from primary care only [default
-    tmp_t2dm_ctv3_date]
+    tmp_t2dm_primarycare_date]
     
     --tmp_t2dm_count_num=T2DM_COUNT_VARNAME
     Count of all recorded Type 2 DM diagnosis codes, from both primary and
@@ -109,12 +117,12 @@ input variables, find
     https://www.opencodelists.org/codelist/user/hjforbes/nondiagnostic-diabetes-codes/50f30a3b/)
     only [default tmp_poccdm_date]
     
-    --tmp_poccdm_ctv3_count_num=NON_DIAG_DM_CODE_COUNT_VARNAME
+    --tmp_poccdm_primarycare_count_num=NON_DIAG_DM_CODE_COUNT_VARNAME
     Count of all recorded Non-diagnostic DM codes, from primary care only [default
-    tmp_poccdm_ctv3_count_num]
+    tmp_poccdm_primarycare_count_num]
     
     --tmp_max_hba1c_mmol_mol_num=MAX_HBA1C_VARNAME
-    Maximum HbA1c value recorded in query period, in mmol/mol (use
+    Maximum HbA1c value recorded in query period, in mmol/mol (e.g.
     https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests-numerical-value/5134e926/)
     from primary care only [default tmp_max_hba1c_mmol_mol_num]
     
@@ -147,6 +155,35 @@ input variables, find
     otherdm_date, gestationaldm_date, tmp_poccdm_date,
     tmp_nonmetform_drugs_dmd_date, and tmp_diabetes_medication_date [default
     tmp_first_diabetes_diag_date]
+    
+    --gestationaldm_date_sources=DIAGNOSIS_DATE_SOURCES
+    Choose which dates are the source to define the baseline date for Gestational
+    DM (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date,
+    otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5
+    mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7)
+    [default gestationaldm_date]
+    
+    --t1dm_date_sources=DIAGNOSIS_DATE_SOURCES
+    Choose which dates are the source to define the baseline date for Type 1 DM
+    (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date,
+    otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5
+    mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7)
+    [default t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date]
+    
+    --t2dm_date_sources=DIAGNOSIS_DATE_SOURCES
+    Choose which dates are the source to define the baseline date for Type 2 DM
+    (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date,
+    otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5
+    mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7)
+    [default t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date]
+    
+    --otherdm_date_sources=DIAGNOSIS_DATE_SOURCES
+    Choose which dates are the source to define the baseline date for Other DM
+    (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date,
+    otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5
+    mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7)
+    [default
+    t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date,tmp_max_hba1c_date,tmp_poccdm_date]
     
     --df_output=FILENAME.CSV.GZ
     Output dataset. csv.gz or rds file. This is assumed to be added to the
@@ -190,7 +227,7 @@ diabetes_algo:
   run: >
     diabetes-algo:[version]
       --birth_date=your_dob_date_variable
-      --tmp_t1dm_ctv3_date=your_t2dm_from_primcare_date_variable
+      --tmp_t1dm_primarycare_date=your_t2dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
       --df_output=data_processed.csv.gz #or data_processed.rds
@@ -217,7 +254,7 @@ diabetes_algo_via_config:
   config:
       df_input: input.arrow
       birth_date: your_dob_date_variable
-      tmp_t1dm_ctv3_date: your_t2dm_from_primcare_date_variable
+      tmp_t1dm_primarycare_date: your_t2dm_from_primcare_date_variable
       ## more arguments
       df_output: data_processed.csv.gz #or data_processed.rds
   needs:

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -12,7 +12,7 @@
 # 10 Save output dataset (data_processed.rds)
 ################################################################################
 
-print("diabetes-algo version: v0.0.9")
+print("diabetes-algo version: v0.0.10")
 
 ################################################################################
 # Import libraries and functions
@@ -37,18 +37,18 @@ option_list <- list(
               help = "Input dataset. csv, csv.gz, rds, arrow, or a feather file. Assumed to be within the directory 'output' [default %default]",
               metavar = "filename.csv"),
   make_option("--remove_helper", type = "logical", default = TRUE,
-              help = "Logical, indicating whether all helper variables (_tmp and step_) are removed [default %default]",
+              help = "Logical, indicating whether all helper variables (tmp_ and step_) are removed [default %default]",
               metavar = "TRUE/FALSE"),
   make_option("--birth_date", type = "character", default = "birth_date",
               help = "Birth date [default %default]",
               metavar = "YYYY-MM-DD"),
   make_option("--ethnicity_cat", type = "character", default = "ethnicity_cat",
-              help = "Ethnicity, in 6 categories, coded as follows: White, Mixed, Asian, Black, Other, Unknown. Guidance (https://pubmed.ncbi.nlm.nih.gov/38987774/) [default %default]",
+              help = "Ethnicity, in 6 categories, coded as follows: White, Mixed, Asian, Black, Other, Unknown. Guidance: https://pubmed.ncbi.nlm.nih.gov/38987774/ [default %default]",
               metavar = "ethnicity_varname"),
   make_option("--t1dm_date", type = "character", default = "t1dm_date",
               help = "First type 1 DM diagnosis date, from both primary (e.g. https://www.opencodelists.org/codelist/user/hjforbes/type-1-diabetes/674fbd7a/) and secondary (e.g. https://www.opencodelists.org/codelist/user/alainamstutz/type-1-diabetes-secondary-care/5eab6d93/) care [default %default]",
               metavar = "YYYY-MM-DD"),
-  make_option("--tmp_t1dm_ctv3_date", type = "character", default = "tmp_t1dm_ctv3_date",
+  make_option("--tmp_t1dm_primarycare_date", type = "character", default = "tmp_t1dm_primarycare_date",
               help = "First type 1 DM diagnosis date, from primary care only [default %default]",
               metavar = "YYYY-MM-DD"),
   make_option("--tmp_t1dm_count_num", type = "character", default = "tmp_t1dm_count_num",
@@ -57,7 +57,7 @@ option_list <- list(
   make_option("--t2dm_date", type = "character", default = "t2dm_date",
               help = "First type 2 DM diagnosis date, from both primary (e.g. https://www.opencodelists.org/codelist/user/hjforbes/type-2-diabetes/3530d710/) and secondary (e.g. https://www.opencodelists.org/codelist/user/alainamstutz/type-2-diabetes-secondary-care/77bae0c8/) care [default %default]",
               metavar = "YYYY-MM-DD"),
-  make_option("--tmp_t2dm_ctv3_date", type = "character", default = "tmp_t2dm_ctv3_date",
+  make_option("--tmp_t2dm_primarycare_date", type = "character", default = "tmp_t2dm_primarycare_date",
               help = "First type 2 DM diagnosis date, from primary care only [default %default]",
               metavar = "YYYY-MM-DD"),
   make_option("--tmp_t2dm_count_num", type = "character", default = "tmp_t2dm_count_num",
@@ -75,11 +75,11 @@ option_list <- list(
   make_option("--tmp_poccdm_date", type = "character", default = "tmp_poccdm_date",
               help = "First Non-diagnostic DM code date, from primary care (e.g. https://www.opencodelists.org/codelist/user/hjforbes/nondiagnostic-diabetes-codes/50f30a3b/) only [default %default]",
               metavar = "YYYY-MM-DD"),
-  make_option("--tmp_poccdm_ctv3_count_num", type = "character", default = "tmp_poccdm_ctv3_count_num",
+  make_option("--tmp_poccdm_primarycare_count_num", type = "character", default = "tmp_poccdm_primarycare_count_num",
               help = "Count of all recorded Non-diagnostic DM codes, from primary care only [default %default]",
               metavar = "non_diag_dm_code_count_varname"),
   make_option("--tmp_max_hba1c_mmol_mol_num", type = "character", default = "tmp_max_hba1c_mmol_mol_num",
-              help = "Maximum HbA1c value recorded in query period, in mmol/mol (use https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests-numerical-value/5134e926/) from primary care only [default %default]",
+              help = "Maximum HbA1c value recorded in query period, in mmol/mol (e.g. https://www.opencodelists.org/codelist/opensafely/glycated-haemoglobin-hba1c-tests-numerical-value/5134e926/) from primary care only [default %default]",
               metavar = "max_hba1c_varname"),
   make_option("--tmp_max_hba1c_date", type = "character", default = "tmp_max_hba1c_date",
               help = "First maximum HbA1c value date, from primary care only [default %default]",
@@ -99,6 +99,18 @@ option_list <- list(
   make_option("--tmp_first_diabetes_diag_date", type = "character", default = "tmp_first_diabetes_diag_date",
               help = "First diabetes diagnosis date variable, i.e. minimum of t1dm_date, t2dm_date, otherdm_date, gestationaldm_date, tmp_poccdm_date, tmp_nonmetform_drugs_dmd_date, and tmp_diabetes_medication_date [default %default]",
               metavar = "YYYY-MM-DD"),
+  make_option("--gestationaldm_date_sources", type = "character", default = "gestationaldm_date",
+              help = "Choose which dates are the source to define the baseline date for Gestational DM (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date, otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5 mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7) [default %default]",
+              metavar = "diagnosis_date_sources"),
+  make_option("--t1dm_date_sources", type = "character", default = "t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date",
+              help = "Choose which dates are the source to define the baseline date for Type 1 DM (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date, otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5 mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7) [default %default]",
+              metavar = "diagnosis_date_sources"),
+  make_option("--t2dm_date_sources", type = "character", default = "t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date",
+              help = "Choose which dates are the source to define the baseline date for Type 2 DM (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date, otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5 mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7) [default %default]",
+              metavar = "diagnosis_date_sources"),
+  make_option("--otherdm_date_sources", type = "character", default = "t2dm_date,t1dm_date,otherdm_date,tmp_diabetes_medication_date,tmp_max_hba1c_date,tmp_poccdm_date",
+              help = "Choose which dates are the source to define the baseline date for Other DM (minimum of these). Options: t2dm_date, t1dm_date, gestationaldm_date, otherdm_date, tmp_diabetes_medication_date, tmp_max_hba1c_date (If >= 47.5 mmol/mol, see step 7), tmp_poccdm_date (If > 5 process codes, see step 7) [default %default]",
+              metavar = "diagnosis_date_sources"),
   make_option("--df_output", type = "character", default = "data_processed.csv.gz",
               help = "Output dataset. csv.gz or rds file. This is assumed to be added to the directory 'output' [default %default]",
               metavar = "filename.csv.gz"),
@@ -148,17 +160,17 @@ print("Map user variable names")
 column_mapping <- list(
   birth_date = opt$birth_date,
   ethnicity_cat = opt$ethnicity_cat,
-  tmp_t1dm_ctv3_date = opt$tmp_t1dm_ctv3_date,
+  tmp_t1dm_primarycare_date = opt$tmp_t1dm_primarycare_date,
   t1dm_date = opt$t1dm_date,
   tmp_t1dm_count_num = opt$tmp_t1dm_count_num,
-  tmp_t2dm_ctv3_date = opt$tmp_t2dm_ctv3_date,
+  tmp_t2dm_primarycare_date = opt$tmp_t2dm_primarycare_date,
   t2dm_date = opt$t2dm_date,
   tmp_t2dm_count_num = opt$tmp_t2dm_count_num,
   otherdm_date = opt$otherdm_date,
   tmp_otherdm_count_num = opt$tmp_otherdm_count_num,
   gestationaldm_date = opt$gestationaldm_date,
   tmp_poccdm_date = opt$tmp_poccdm_date,
-  tmp_poccdm_ctv3_count_num = opt$tmp_poccdm_ctv3_count_num,
+  tmp_poccdm_primarycare_count_num = opt$tmp_poccdm_primarycare_count_num,
   tmp_max_hba1c_mmol_mol_num = opt$tmp_max_hba1c_mmol_mol_num,
   tmp_max_hba1c_date = opt$tmp_max_hba1c_date,
   tmp_insulin_dmd_date = opt$tmp_insulin_dmd_date,
@@ -177,6 +189,16 @@ if (length(missing_columns) > 0) {
 
 print("Extract core data and patient_id")
 core <- data[c("patient_id", unlist(column_mapping))]
+
+################################################################################
+# Parse the diagnosis date source input string
+################################################################################
+diagnosis_date_sources <- list(
+  gestationaldm = strsplit(opt$gestationaldm_date_sources, ",")[[1]],
+  t1dm = strsplit(opt$t1dm_date_sources, ",")[[1]],
+  t2dm = strsplit(opt$t2dm_date_sources, ",")[[1]],
+  otherdm = strsplit(opt$otherdm_date_sources, ",")[[1]]
+)
 
 ################################################################################
 # Double-check the imported core variables
@@ -245,8 +267,8 @@ core <- core %>%
 ################################################################################
 # Apply the diabetes algorithm
 ################################################################################
-print("Apply the diabetes algorithm and delete all tmp & step variables")
-core <- fn_diabetes_algorithm(core, column_mapping)
+print("Apply the diabetes algorithm")
+core <- fn_diabetes_algorithm(core, column_mapping, diagnosis_date_sources)
 
 ################################################################################
 # Merge the core back to the user data

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -68,27 +68,27 @@ dataset.ethnicity_cat = case(
 
 ## Type 1 Diabetes 
 # First date from primary+secondary, but also primary care date separately for diabetes algo
-dataset.tmp_t1dm_ctv3_date = first_matching_event_clinical_ctv3_before(diabetes_type1_ctv3, index_date).date
+dataset.tmp_t1dm_primarycare_date = first_matching_event_clinical_ctv3_before(diabetes_type1_ctv3, index_date).date
 dataset.t1dm_date = minimum_of(
     (first_matching_event_clinical_ctv3_before(diabetes_type1_ctv3, index_date).date),
     (first_matching_event_apc_before(diabetes_type1_icd10, index_date).admission_date)
 )
 # Count codes (individually and together, for diabetes algo)
-tmp_t1dm_ctv3_count = count_matching_event_clinical_ctv3_before(diabetes_type1_ctv3, index_date)
+tmp_t1dm_primarycare_count = count_matching_event_clinical_ctv3_before(diabetes_type1_ctv3, index_date)
 tmp_t1dm_hes_count = count_matching_event_apc_before(diabetes_type1_icd10, index_date)
-dataset.tmp_t1dm_count_num = tmp_t1dm_ctv3_count + tmp_t1dm_hes_count
+dataset.tmp_t1dm_count_num = tmp_t1dm_primarycare_count + tmp_t1dm_hes_count
 
 ## Type 2 Diabetes
 # First date from primary+secondary, but also primary care date separately for diabetes algo)
-dataset.tmp_t2dm_ctv3_date = first_matching_event_clinical_ctv3_before(diabetes_type2_ctv3, index_date).date
+dataset.tmp_t2dm_primarycare_date = first_matching_event_clinical_ctv3_before(diabetes_type2_ctv3, index_date).date
 dataset.t2dm_date = minimum_of(
     (first_matching_event_clinical_ctv3_before(diabetes_type2_ctv3, index_date).date),
     (first_matching_event_apc_before(diabetes_type2_icd10, index_date).admission_date)
 )
 # Count codes (individually and together, for diabetes algo)
-tmp_t2dm_ctv3_count = count_matching_event_clinical_ctv3_before(diabetes_type2_ctv3, index_date)
+tmp_t2dm_primarycare_count = count_matching_event_clinical_ctv3_before(diabetes_type2_ctv3, index_date)
 tmp_t2dm_hes_count = count_matching_event_apc_before(diabetes_type2_icd10, index_date)
-dataset.tmp_t2dm_count_num = tmp_t2dm_ctv3_count + tmp_t2dm_hes_count
+dataset.tmp_t2dm_count_num = tmp_t2dm_primarycare_count + tmp_t2dm_hes_count
 
 ## Diabetes unspecified/other
 # First date
@@ -107,7 +107,7 @@ dataset.gestationaldm_date = minimum_of(
 # First date
 dataset.tmp_poccdm_date = first_matching_event_clinical_ctv3_before(diabetes_diagnostic_ctv3, index_date).date
 # Count codes
-dataset.tmp_poccdm_ctv3_count_num = count_matching_event_clinical_ctv3_before(diabetes_diagnostic_ctv3, index_date)
+dataset.tmp_poccdm_primarycare_count_num = count_matching_event_clinical_ctv3_before(diabetes_diagnostic_ctv3, index_date)
 
 ### Other variables needed to define diabetes
 ## HbA1c

--- a/analysis/functions/fn_diabetes_algorithm.R
+++ b/analysis/functions/fn_diabetes_algorithm.R
@@ -1,19 +1,41 @@
-fn_diabetes_algorithm <- function(data, column_mapping) {
+fn_diabetes_algorithm <- function(data, column_mapping, diagnosis_date_sources = NULL) {
+
+  # Set default date sources if not provided
+  if (is.null(diagnosis_date_sources)) {
+    diagnosis_date_sources <- list(
+      gestationaldm = c("gestationaldm_date"),
+      t1dm = c("t2dm_date", "t1dm_date", "otherdm_date", "tmp_diabetes_medication_date"),
+      t2dm = c("t2dm_date", "t1dm_date", "otherdm_date", "tmp_diabetes_medication_date"),
+      otherdm = c("t2dm_date", "t1dm_date", "otherdm_date", "tmp_diabetes_medication_date",
+                  "tmp_max_hba1c_date", "tmp_poccdm_date")
+    )
+  }
+
+  # Validate date sources
+  valid_sources <- c("t2dm_date", "t1dm_date", "otherdm_date", "gestationaldm_date",
+                     "tmp_diabetes_medication_date", "tmp_max_hba1c_date", "tmp_poccdm_date")
+  for (dm_type in c("gestationaldm", "t1dm", "t2dm", "otherdm")) {
+    invalid <- setdiff(diagnosis_date_sources[[dm_type]], valid_sources)
+    if (length(invalid) > 0) {
+      stop(paste0("Invalid date sources for ", dm_type, ": ", paste(invalid, collapse = ", ")))
+    }
+  }
+
   data <- data %>%
     rename(
       birth_date = all_of(column_mapping$birth_date),
       ethnicity_cat = all_of(column_mapping$ethnicity_cat),
-      tmp_t1dm_ctv3_date = all_of(column_mapping$tmp_t1dm_ctv3_date),
+      tmp_t1dm_primarycare_date = all_of(column_mapping$tmp_t1dm_primarycare_date),
       t1dm_date = all_of(column_mapping$t1dm_date),
       tmp_t1dm_count_num = all_of(column_mapping$tmp_t1dm_count_num),
-      tmp_t2dm_ctv3_date = all_of(column_mapping$tmp_t2dm_ctv3_date),
+      tmp_t2dm_primarycare_date = all_of(column_mapping$tmp_t2dm_primarycare_date),
       t2dm_date = all_of(column_mapping$t2dm_date),
       tmp_t2dm_count_num = all_of(column_mapping$tmp_t2dm_count_num),
       otherdm_date = all_of(column_mapping$otherdm_date),
       tmp_otherdm_count_num = all_of(column_mapping$tmp_otherdm_count_num),
       gestationaldm_date = all_of(column_mapping$gestationaldm_date),
       tmp_poccdm_date = all_of(column_mapping$tmp_poccdm_date),
-      tmp_poccdm_ctv3_count_num = all_of(column_mapping$tmp_poccdm_ctv3_count_num),
+      tmp_poccdm_primarycare_count_num = all_of(column_mapping$tmp_poccdm_primarycare_count_num),
       tmp_max_hba1c_mmol_mol_num = all_of(column_mapping$tmp_max_hba1c_mmol_mol_num),
       tmp_max_hba1c_date = all_of(column_mapping$tmp_max_hba1c_date),
       tmp_insulin_dmd_date = all_of(column_mapping$tmp_insulin_dmd_date),
@@ -36,7 +58,7 @@ fn_diabetes_algorithm <- function(data, column_mapping) {
                                                TRUE ~ "No"), # prevents any NA: Those with DM but not fulfilling the condition OR those without DM at all -> "No"
       tmp_hba1c_date_step7 = case_when(!is.na(tmp_max_hba1c_mmol_mol_num) & tmp_max_hba1c_mmol_mol_num >= 47.5 ~ tmp_max_hba1c_date,
                                        TRUE ~ as.Date(NA)),
-      tmp_over5_pocc_step7 = case_when(!is.na(tmp_poccdm_ctv3_count_num) & tmp_poccdm_ctv3_count_num >= 5 ~ tmp_poccdm_date,
+      tmp_over5_pocc_step7 = case_when(!is.na(tmp_poccdm_primarycare_count_num) & tmp_poccdm_primarycare_count_num >= 5 ~ tmp_poccdm_date,
                                        TRUE ~ as.Date(NA))) %>%
 
     ## --- Step 1: Any gestational diabetes code?
@@ -81,13 +103,13 @@ fn_diabetes_algorithm <- function(data, column_mapping) {
            ) %>%
 
     ## --- Step 6a. In primary care, only type 1 DM diagnostic codes reported? Denominator: Step 6 == Yes
-    mutate(step_6a = case_when(step_6 == "Yes" & !is.na(tmp_t1dm_ctv3_date) & is.na(tmp_t2dm_ctv3_date) ~ "Yes",
+    mutate(step_6a = case_when(step_6 == "Yes" & !is.na(tmp_t1dm_primarycare_date) & is.na(tmp_t2dm_primarycare_date) ~ "Yes",
                                step_6 == "Yes" ~ "No",
                                TRUE ~ NA_character_) # NA will only be fulfilled if not part of denominator
            ) %>%
 
     ## --- Step 6b. In primary care, only type 2 DM diagnostic codes reported? Denominator: Step 6a == No
-    mutate(step_6b = case_when(step_6a == "No" & is.na(tmp_t1dm_ctv3_date) & !is.na(tmp_t2dm_ctv3_date) ~ "Yes",
+    mutate(step_6b = case_when(step_6a == "No" & is.na(tmp_t1dm_primarycare_date) & !is.na(tmp_t2dm_primarycare_date) ~ "Yes",
                                step_6a == "No" ~ "No",
                                TRUE ~ NA_character_) # NA will only be fulfilled if not part of denominator
            ) %>%
@@ -114,7 +136,7 @@ fn_diabetes_algorithm <- function(data, column_mapping) {
     mutate(step_7 = case_when(step_6 == "No" # this includes only people with both missing t1dm_date & t2dm_date (otherwise fished out further above)
                               & ((!is.na(tmp_diabetes_medication_date)) |
                                    (tmp_max_hba1c_mmol_mol_num >= 47.5) |
-                                   (tmp_poccdm_ctv3_count_num >= 5)) ~ "Yes", # any other valid evidence for a diabetes, i.e. "unspecified Diabetes"?
+                                   (tmp_poccdm_primarycare_count_num >= 5)) ~ "Yes", # any other valid evidence for a diabetes, i.e. "unspecified Diabetes"?
                               step_6 == "No" ~ "No", # => Diabetes unlikely
                               TRUE ~ NA_character_) # NA will only be fulfilled if not part of denominator.
     ) %>%
@@ -177,21 +199,69 @@ fn_diabetes_algorithm <- function(data, column_mapping) {
 
 
     ## --- Assignment of the diagnosis date ---
-    # Define the incident diabetes date variables ("diagnosis date") for each diabetes type category
+    # Define the incident diabetes date variables ("diagnosis date") for each diabetes type category (user-customizable)
 
-           # GESTATIONAL
-    mutate(gestationaldm_date = as_date(case_when(cat_diabetes == "GDM" ~ gestationaldm_date,
-                                                  TRUE ~ as.Date(NA))),
-           # T2DM
-           t2dm_date = as_date(case_when(cat_diabetes == "T2DM" ~ pmin(t2dm_date, t1dm_date, otherdm_date, tmp_diabetes_medication_date, na.rm = TRUE),
-                                         TRUE ~ as.Date(NA))),
-           # T1DM
-           t1dm_date = as_date(case_when(cat_diabetes == "T1DM" ~ pmin(t2dm_date, t1dm_date, otherdm_date, tmp_diabetes_medication_date, na.rm = TRUE),
-                                         TRUE ~ as.Date(NA))),
-           # OTHER
-           otherdm_date = as_date(case_when(cat_diabetes == "DM_other" ~ pmin(t2dm_date, t1dm_date, otherdm_date, tmp_diabetes_medication_date, tmp_hba1c_date_step7, tmp_over5_pocc_step7, na.rm = TRUE),
-                                            TRUE ~ as.Date(NA)))
-           )
+    {
+      # Helper function to calculate minimum date from user-specified sources
+      calc_min_date <- function(dm_type, data_cols) {
+        sources <- diagnosis_date_sources[[dm_type]]
+        date_cols <- intersect(sources, names(data_cols))
+        if (length(date_cols) == 0) {
+          return(as.Date(NA))
+        }
+        do.call(pmin, c(data_cols[date_cols], na.rm = TRUE))
+      }
+
+      mutate(.,
+             # GDM (user-customizable)
+             gestationaldm_date = as_date(case_when(
+               cat_diabetes == "GDM" ~ calc_min_date("gestationaldm",
+                                                     list(t2dm_date = t2dm_date,
+                                                          t1dm_date = t1dm_date,
+                                                          gestationaldm_date = gestationaldm_date,
+                                                          otherdm_date = otherdm_date,
+                                                          tmp_diabetes_medication_date = tmp_diabetes_medication_date,
+                                                          tmp_max_hba1c_date = tmp_hba1c_date_step7, # takes the user input date variable, but is slightly modified above
+                                                          tmp_poccdm_date = tmp_over5_pocc_step7)), # takes the user input date variable, but is slightly modified above
+               TRUE ~ as.Date(NA))),
+
+             # T2DM (user-customizable)
+             t2dm_date = as_date(case_when(
+               cat_diabetes == "T2DM" ~ calc_min_date("t2dm",
+                                                      list(t2dm_date = t2dm_date,
+                                                           t1dm_date = t1dm_date,
+                                                           gestationaldm_date = gestationaldm_date,
+                                                           otherdm_date = otherdm_date,
+                                                           tmp_diabetes_medication_date = tmp_diabetes_medication_date,
+                                                           tmp_max_hba1c_date = tmp_hba1c_date_step7,
+                                                           tmp_poccdm_date = tmp_over5_pocc_step7)),
+               TRUE ~ as.Date(NA))),
+
+             # T1DM (user-customizable)
+             t1dm_date = as_date(case_when(
+               cat_diabetes == "T1DM" ~ calc_min_date("t1dm",
+                                                      list(t2dm_date = t2dm_date,
+                                                           t1dm_date = t1dm_date,
+                                                           gestationaldm_date = gestationaldm_date,
+                                                           otherdm_date = otherdm_date,
+                                                           tmp_diabetes_medication_date = tmp_diabetes_medication_date,
+                                                           tmp_max_hba1c_date = tmp_hba1c_date_step7,
+                                                           tmp_poccdm_date = tmp_over5_pocc_step7)),
+               TRUE ~ as.Date(NA))),
+
+             # OTHER (user-customizable)
+             otherdm_date = as_date(case_when(
+               cat_diabetes == "DM_other" ~ calc_min_date("otherdm",
+                                                          list(t2dm_date = t2dm_date,
+                                                               t1dm_date = t1dm_date,
+                                                               gestationaldm_date = gestationaldm_date,
+                                                               otherdm_date = otherdm_date,
+                                                               tmp_diabetes_medication_date = tmp_diabetes_medication_date,
+                                                               tmp_max_hba1c_date = tmp_hba1c_date_step7,
+                                                               tmp_poccdm_date = tmp_over5_pocc_step7)),
+               TRUE ~ as.Date(NA)))
+      )
+    }
 
   return(data)
 }

--- a/project.yaml
+++ b/project.yaml
@@ -41,6 +41,11 @@ actions:
     run: r:v2 analysis/data_process.R
     config:
       df_input: input.arrow
+      remove_helper: FALSE
+      gestationaldm_date_sources: gestationaldm_date
+      t1dm_date_sources: t2dm_date,t1dm_date,otherdm_date,gestationaldm_date,tmp_diabetes_medication_date,tmp_max_hba1c_date,tmp_poccdm_date
+      t2dm_date_sources: t2dm_date,t1dm_date,otherdm_date,gestationaldm_date,tmp_diabetes_medication_date,tmp_max_hba1c_date,tmp_poccdm_date
+      otherdm_date_sources: t2dm_date,t1dm_date,otherdm_date,gestationaldm_date,tmp_diabetes_medication_date,tmp_max_hba1c_date,tmp_poccdm_date
       df_output: data_processed_3.csv.gz
     needs:
     - generate_dataset_3


### PR DESCRIPTION
1) Added 4 new input args to customize the diagnosis date sources for each of the 4 output diabetes types

2) Deleted all mention of ctv3 (replaced with "primarycare") to clarify that input codelists can be any primary care codelist (snomed or ctv3) and these are just examples.