### PR TITLE
Fix changelog and prevent dependabot from creating Git tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
 
   tag-new-version:
     needs: [test-integration]
+    if: github.event.head_commit.author.username != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.0.13](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.13)
+
+* Add omitted entry to CHANGELOG
+
 # [v0.0.12](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.12)
 
 * Bump pipeline version in *project.yaml*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# [v0.0.11](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.11)
+# [v0.0.12](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.12)
 
 * Bump pipeline version in *project.yaml*
+
+# [v0.0.11](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.11)
+
+* Bump actions/checkout from 5 to 6
 
 # [v0.0.10](https://github.com/opensafely-actions/diabetes-algo/releases/tag/v0.0.10)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -61,8 +61,8 @@ knitr::include_graphics("diabetes-algo_fig.png")
 ```
 
 This action can be specified in the `project.yaml` with its options at their default values as follows, 
-where you should replace `[version]` with the latest tag from 
-[here](xy), e.g., `v0.0.1`. 
+where you should replace `[version]` with the latest tag from
+[here](https://github.com/opensafely-actions/diabetes-algo/tags), e.g., `v0.0.1`.
 Note that no space is allowed between `diabetes-algo:` and `[version]`.
 This action can be run specifying input arguments as follows (in YAML ">" indicates to treat the subsequent nested lines as a single line).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,7 +77,7 @@ diabetes_algo:
   run: >
     diabetes-algo:[version]
       --birth_date=your_dob_date_variable
-      --tmp_t1dm_primarycare_date=your_t2dm_from_primcare_date_variable
+      --tmp_t1dm_primarycare_date=your_t1dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
       --df_output=data_processed.csv.gz #or data_processed.rds
@@ -103,7 +103,7 @@ diabetes_algo_via_config:
   config:
       df_input: input.arrow
       birth_date: your_dob_date_variable
-      tmp_t1dm_primarycare_date: your_t2dm_from_primcare_date_variable
+      tmp_t1dm_primarycare_date: your_t1dm_from_primcare_date_variable
       ## more arguments
       df_output: data_processed.csv.gz #or data_processed.rds
   needs:

--- a/README.md
+++ b/README.md
@@ -211,10 +211,12 @@ Figure 1.
 
 This action can be specified in the `project.yaml` with its options at
 their default values as follows, where you should replace `[version]`
-with the latest tag from [here](xy), e.g., `v0.0.1`. Note that no space
-is allowed between `diabetes-algo:` and `[version]`. This action can be
-run specifying input arguments as follows (in YAML “\>” indicates to
-treat the subsequent nested lines as a single line).
+with the latest tag from
+[here](https://github.com/opensafely-actions/diabetes-algo/tags), e.g.,
+`v0.0.1`. Note that no space is allowed between `diabetes-algo:` and
+`[version]`. This action can be run specifying input arguments as
+follows (in YAML “\>” indicates to treat the subsequent nested lines as
+a single line).
 
 ``` yaml
 generate_dataset:
@@ -227,7 +229,7 @@ diabetes_algo:
   run: >
     diabetes-algo:[version]
       --birth_date=your_dob_date_variable
-      --tmp_t1dm_primarycare_date=your_t2dm_from_primcare_date_variable
+      --tmp_t1dm_primarycare_date=your_t1dm_from_primcare_date_variable
       --tmp_max_hba1c_mmol_mol_num=your_max_hba1c_num_variable
       --## more arguments
       --df_output=data_processed.csv.gz #or data_processed.rds
@@ -254,7 +256,7 @@ diabetes_algo_via_config:
   config:
       df_input: input.arrow
       birth_date: your_dob_date_variable
-      tmp_t1dm_primarycare_date: your_t2dm_from_primcare_date_variable
+      tmp_t1dm_primarycare_date: your_t1dm_from_primcare_date_variable
       ## more arguments
       df_output: data_processed.csv.gz #or data_processed.rds
   needs:

--- a/analysis/data_process.R
+++ b/analysis/data_process.R
@@ -12,7 +12,7 @@
 # 10 Save output dataset (data_processed.rds)
 ################################################################################
 
-print("diabetes-algo version: v0.0.11")
+print("diabetes-algo version: v0.0.13")
 
 ################################################################################
 # Import libraries and functions

--- a/analysis/functions/fn_diabetes_algorithm.R
+++ b/analysis/functions/fn_diabetes_algorithm.R
@@ -128,7 +128,7 @@ fn_diabetes_algorithm <- function(data, column_mapping, diagnosis_date_sources =
 
     ## --- Step 6e. Type 2 DM diagnostic code is more recent than type 1 DM diagnostic code? Denominator: Step 6d == No
     mutate(step_6e = case_when(step_6d == "No" & t2dm_date > t1dm_date ~ "Yes",
-                               step_6d == "No" & t2dm_date <= t1dm_date ~ "No", # I think the second part of this condition can be removed, since all that end up here have a t2dm_date and t1dm_date (step 6)? Currently Type 1 overrules Type 2 in case they have exactly the same date (extrem edge case), which I think it reasonable. If we remove the second part, the same will apply by default.
+                               step_6d == "No" & t2dm_date <= t1dm_date ~ "No", # I think the second part of this condition can be removed, since all that end up here have a t2dm_date and t1dm_date (step 6)? Currently Type 1 overrules Type 2 in case they have exactly the same date (extreme edge case), which I think is reasonable. If we remove the second part, the same will apply by default.
                                TRUE ~ NA_character_) # NA will only be fulfilled if not part of denominator
     ) %>%
 


### PR DESCRIPTION
There was an accidentally omitted entry in the CHANGELOG due to the dependabot PR not adding entries to the files.

This fixes the CHANGELOG and amends the CI workflow to not generate a Git tag if the PR is by dependabot.